### PR TITLE
Endpoint listado de taxis

### DIFF
--- a/fleet-Management-Software-API/src/main/java/com/fleetManagementSoftwareAPI/taxis/TaxisController.java
+++ b/fleet-Management-Software-API/src/main/java/com/fleetManagementSoftwareAPI/taxis/TaxisController.java
@@ -1,8 +1,10 @@
 package com.fleetManagementSoftwareAPI.taxis;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -10,6 +12,7 @@ import java.util.List;
 @RestController
 @RequestMapping(path = "/taxis")
 public class TaxisController {
+
 
     public final TaxisService taxisService;
 
@@ -19,8 +22,9 @@ public class TaxisController {
     }
 
     @GetMapping()
-    public List<Taxis> getTaxis(){
-        return taxisService.getTaxis();
+    public Page<Taxis> getTaxis(@RequestParam(defaultValue = "0") int pageNumber,
+                                @RequestParam(defaultValue = "10") int pageSize){
+        return taxisService.getTaxis(pageNumber, pageSize);
     }
 
 }

--- a/fleet-Management-Software-API/src/main/java/com/fleetManagementSoftwareAPI/taxis/TaxisService.java
+++ b/fleet-Management-Software-API/src/main/java/com/fleetManagementSoftwareAPI/taxis/TaxisService.java
@@ -1,9 +1,10 @@
 package com.fleetManagementSoftwareAPI.taxis;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 public class TaxisService {
@@ -15,8 +16,9 @@ public class TaxisService {
         this.taxiRepository = taxiRepository;
     }
 
-    public List<Taxis> getTaxis(){
-        return taxiRepository.findAll();
+    public Page<Taxis> getTaxis(int initPage, int pageSize){
+        Pageable pageNumber = PageRequest.of(initPage, pageSize);
+        return taxiRepository.findAll(pageNumber);
     }
 
 }


### PR DESCRIPTION
**Criterios de aceptación**
El endpoint paginamos los resultados para asegurar que las respuestas sean más fáciles de manejar: el endpoint implementa la paginación de resultados. Esto significa que al solicitar la lista de taxis, se deben devolver solo un número limitado de resultados por página, lo que facilita el manejo de grandes conjuntos de datos.